### PR TITLE
Allow parameterising `secret_key` and `ttl`

### DIFF
--- a/lib/branca.rb
+++ b/lib/branca.rb
@@ -13,7 +13,8 @@ module Branca
 
     attr_accessor :secret_key, :ttl
 
-    def encode(message, timestamp = Time.now.utc)
+    def encode(message, timestamp = Time.now.utc, secret_key: self.secret_key)
+      cipher = RbNaCl::AEAD::XChaCha20Poly1305IETF.new(secret_key)
       nonce = RbNaCl::Random.random_bytes(cipher.nonce_bytes)
 
       header = [VERSION, timestamp.to_i].pack('C N') + nonce
@@ -23,14 +24,18 @@ module Branca
       BaseX::Base62.encode(raw_token)
     end
 
-    def decode(token)
+    def decode(token, ttl: self.ttl, secret_key: self.secret_key)
       header, bytes = token_explode(token)
       version, timestamp, nonce = header_explode(header)
 
       raise VersionError unless version == VERSION
-      raise ExpiredTokenError if (timestamp + Branca.ttl) < Time.now.utc.to_i
+      raise ExpiredTokenError if (timestamp + ttl) < Time.now.utc.to_i
 
+      cipher = RbNaCl::AEAD::XChaCha20Poly1305IETF.new(secret_key)
       message = cipher.decrypt(nonce, bytes.pack('C*'), header.pack('C*'))
+    rescue RbNaCl::CryptoError
+      raise DecodeError
+    else
       Decoder.new(message, Time.at(timestamp).utc)
     end
 
@@ -47,10 +52,6 @@ module Branca
     end
 
     private
-
-    def cipher
-      @cipher ||= RbNaCl::AEAD::XChaCha20Poly1305IETF.new(secret_key)
-    end
 
     def token_explode(token)
       bytes = BaseX::Base62.decode(token).unpack('C C4 C24 C*')


### PR DESCRIPTION
This addresses #1 but with a different approach, which minimises the diff while maintaining backwards compatibility.

This allows context-specific keys to be used for encoding and decoding as well as context-specific ttls:

```rb
key = SecureRandom.bytes(32)
ciphertext = Branca.encode("sensitive information", secret_key: key)
Branca.decode(ciphertext, secret_key: key, ttl: 30)
```